### PR TITLE
Update registry.go – added missing comma

### DIFF
--- a/features/registry.go
+++ b/features/registry.go
@@ -11,7 +11,7 @@ var Registry = Middlewares{
 	// Other directives that don't necessarily create HTTP handlers (services)
 	{"startup", "", ""},
 	{"shutdown", "", ""},
-	{"realip", "github.com/captncraig/caddy-realip", "Restore original IP when behind a proxy."}
+	{"realip", "github.com/captncraig/caddy-realip", "Restore original IP when behind a proxy."},
 	{"git", "github.com/abiosoft/caddy-git", "Deploy your site with git push."},
 
 	// Directives that inject handlers (middleware)


### PR DESCRIPTION
I've tried to `go get github.com/caddyserver/caddydev`
and got an error back

```
# github.com/caddyserver/buildsrv/features
synced/go/src/github.com/caddyserver/buildsrv/features/registry.go:14: syntax error: unexpected semicolon or newline, expecting comma or }
synced/go/src/github.com/caddyserver/buildsrv/features/registry.go:18: syntax error: missing operand
```

try to fix